### PR TITLE
thumbnail option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A very simple Jekyll tag for including lightbox images in your jekyll powered we
 Use this plugin as a Jekyll tag in any of your pages as follows:
 
 ```
-{% lightbox images/appfoundry.png --data="appfoundry_image_set" --title="The AppFoundry Logo" --alt="This is our logo" --img-style="max-width:80%;" --class="yourclass" %}
+{% lightbox images/appfoundry.png --thumb="images/thumbs/appfoundry.png" --data="appfoundry_image_set" --title="The AppFoundry Logo" --alt="This is our logo" --img-style="max-width:80%;" --class="yourclass" %}
 ```
 
 This will ouput:
@@ -25,6 +25,7 @@ This will ouput:
 
 The options explained:
 
+* **--thumb**: corresponds to Lightbox undocumented thumbnail "feature"
 * **--data**: corresponds to the Lightbox `data-lightbox` attribute
 * **--title**: corresponds to the Lightbox `data-title` attribute
 * **--alt**: optional image `alt` value. If ommitted, the value of `title` is used

--- a/lightbox.rb
+++ b/lightbox.rb
@@ -12,12 +12,18 @@ module Jekyll
       # The path to our image
       @path = text.split(/\s+/)[0].strip
 
+      # The path to our thumb
+      @thumb = text.split(/\s+/)[0].strip
+
+
       # Defaults
       @title = ''
       @alt = ''
       @img_style = ''
       @class = ''
       @data = ''
+      @thumb =''
+
 
       # Parse Options
       if text =~ /--title="([^"]*)"/i
@@ -35,6 +41,10 @@ module Jekyll
       if text =~ /--data="([^"]*)"/i
         @data = text.match(/--data="([^"]*)"/i)[1]
       end
+      if text =~ /--thumb="([^"]*)"/i
+        @thumb = text.match(/--thumb="([^"]*)"/i)[1]
+      end
+
 
     end
 
@@ -42,7 +52,7 @@ module Jekyll
       url = context.registers[:page]["url"]
       relative = "../" * (url.split("/").length-1)
       src = File.join(relative, @path == nil ? '' : @path);
-      %{<a href="#{src}" data-lightbox="#{@data}" data-title="#{@title}"><img src="#{src}" alt="#{@alt || @title}" class="#{@class}" style="#{@img_style}"/></a>}
+      %{<a href="#{src}" data-lightbox="#{@data}" data-title="#{@title}"><img src="#{@thumb}" alt="#{@alt || @title}" class="#{@class}" style="#{@img_style}"/></a>}
     end
   end
 end


### PR DESCRIPTION
lightbox2 allows for a thumbnail as well as a source full sized image

this seems to be undocumented but can be seen in source 
http://lokeshdhakar.com/projects/lightbox2/

```
          <h3 style="clear: both;">Four image set</h3>
          <div class="image-row">
            <div class="image-set">
              <a class="example-image-link" href="images/image-3.jpg" data-lightbox="example-set" data-title="Click the right half of the image to move forward."><img class="example-image" src="images/thumb-3.jpg" alt="Golden Gate Bridge with San Francisco in distance"></a>
              <a class="example-image-link" href="images/image-4.jpg" data-lightbox="example-set" data-title="Or press the right arrow on your keyboard."><img class="example-image" src="images/thumb-4.jpg" alt="Forest with mountains behind"></a>
              <a class="example-image-link" href="images/image-5.jpg" data-lightbox="example-set" data-title="The next image in the set is preloaded as you&apos;re viewing."><img class="example-image" src="images/thumb-5.jpg" alt="Bicyclist looking out over hill at ocean"></a>
              <a class="example-image-link" href="images/image-6.jpg" data-lightbox="example-set" data-title="Click anywhere outside the image or the X to the right to close."><img class="example-image" src="images/thumb-6.jpg" alt="Small lighthouse at bottom with ocean behind"></a>
            </div>
          </div>
        </div>
```
