### PR TITLE
Allow Liquid vars and spaces in the path

### DIFF
--- a/lightbox.rb
+++ b/lightbox.rb
@@ -10,7 +10,9 @@ module Jekyll
       super
 
       # The path to our image
-      @path = text.split(/\s+/)[0].strip
+      @path = Liquid::Template.parse(
+        text.split(/\s(?=(?:[^"]|"[^"]*")*$)/)[0].strip
+      ).render(@context)
 
       # Defaults
       @title = ''


### PR DESCRIPTION
Changes regex to allow double quoting for surrounding spaces in a file path and runs the string through the Liquid renderer to expand vars like `{{site.baseurl}}`